### PR TITLE
Possible fix for how Rails starts log entries off with the double newline.

### DIFF
--- a/lib/e20/ops/middleware/hostname_middleware.rb
+++ b/lib/e20/ops/middleware/hostname_middleware.rb
@@ -5,16 +5,16 @@ module E20
 
         def initialize(app, options = {})
           @app = app
+          @options = options  
           @hostname = options[:hostname] || Hostname.new
-
-          if (logger = options[:logger])
-            logger.info "[#{self.class.name}] Running on: #{@hostname}"
-          end
         end
 
         def call(env)
           status, headers, body = @app.call(env)
           headers["X-Served-By"] = @hostname.to_s
+          if (logger = @options[:logger])
+            logger.info "[#{self.class.name}] Running on: #{@hostname}"
+          end
           [status, headers, body]
         end
 

--- a/lib/e20/ops/middleware/revision_middleware.rb
+++ b/lib/e20/ops/middleware/revision_middleware.rb
@@ -5,15 +5,13 @@ module E20
 
         def initialize(app, options = {})
           @app = app
+          @options = options
           @revision = options[:revision] || Revision.new
-
-          if (logger = options[:logger])
-            logger.info "[#{self.class.name}] Running: #{@revision}"
-          end
         end
 
         def call(env)
-          if env["PATH_INFO"] == "/system/revision"
+          
+          response = if env["PATH_INFO"] == "/system/revision"
             body = "#{@revision}\n"
             [200, { "Content-Type" => "text/plain", "Content-Length" => body.size.to_s }, [body]]
           else
@@ -21,6 +19,12 @@ module E20
             headers["X-Revision"] = @revision.to_s
             [status, headers, body]
           end
+          
+          if (logger = @options[:logger])
+            logger.info "[#{self.class.name}] Running: #{@revision}"
+          end
+          
+          response
         end
 
       end

--- a/lib/e20/ops/middleware/transaction_id_middleware.rb
+++ b/lib/e20/ops/middleware/transaction_id_middleware.rb
@@ -14,9 +14,9 @@ module E20
 
         def call(env)
           uuid = @uuid_generator.call.to_s
-          @logger.info "[#{self.class.name}] Transaction ID: #{uuid}"
 
           status, headers, body = @app.call(env)
+          @logger.info "[#{self.class.name}] Transaction ID: #{uuid}"
           headers["X-Transaction"] = uuid
           [status, headers, body]
         end

--- a/spec/ops/middleware/hostname_middleware_spec.rb
+++ b/spec/ops/middleware/hostname_middleware_spec.rb
@@ -15,7 +15,8 @@ describe E20::Ops::Middleware::HostnameMiddleware do
 
   it "logs the hostname when initialized" do
     log_io = StringIO.new
-    E20::Ops::Middleware::HostnameMiddleware.new(app, :logger => Logger.new(log_io))
+    middleware = E20::Ops::Middleware::HostnameMiddleware.new(app, :logger => Logger.new(log_io))
+    status, headers, body = middleware.call({})
     log_io.string.should include("[E20::Ops::Middleware::HostnameMiddleware] Running on: ")
   end
 

--- a/spec/ops/middleware/revision_middleware_spec.rb
+++ b/spec/ops/middleware/revision_middleware_spec.rb
@@ -24,7 +24,8 @@ describe E20::Ops::Middleware::RevisionMiddleware do
 
     it "logs the running revision when initialized" do
       log_io = StringIO.new
-      E20::Ops::Middleware::RevisionMiddleware.new(app, :revision => "rev", :logger => Logger.new(log_io))
+      middleware = E20::Ops::Middleware::RevisionMiddleware.new(app, :revision => "rev", :logger => Logger.new(log_io))
+      status, headers, body = middleware.call({})
       log_io.string.should include("[E20::Ops::Middleware::RevisionMiddleware] Running: rev")
     end
 


### PR DESCRIPTION
modified middlewares to append logs at end of log entry to compensate for rails 2.3.X starting the logs with 2 newlines.

Updated code and tests.  All were green.
