### PR TITLE
add alternative git revision endpoint option, spec, and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Create a `config/initializers/ops_middleware.rb` with the following:
 In `config.ru`, add:
 
     use E20::Ops::Middleware::RevisionMiddleware
+    # alternatively, you may specify the git endpoint:
+    # use E20::Ops::Midleware::RevisionMiddleware path_info: '/some/other/revision/endpoint'
     use E20::Ops::Middleware::HostnameMiddleware
     use E20::Ops::Middleware::TransactionIdMiddleware
 

--- a/lib/e20/ops/middleware/revision_middleware.rb
+++ b/lib/e20/ops/middleware/revision_middleware.rb
@@ -6,6 +6,7 @@ module E20
         def initialize(app, options = {})
           @app = app
           @revision = options[:revision] || Revision.new
+          @path_info = options[:path_info] || '/system/revision'
 
           if (logger = options[:logger])
             logger.info "[#{self.class.name}] Running: #{@revision}"
@@ -13,7 +14,7 @@ module E20
         end
 
         def call(env)
-          if env["PATH_INFO"] == "/system/revision"
+          if env["PATH_INFO"] == @path_info
             body = "#{@revision}\n"
             [200, { "Content-Type" => "text/plain", "Content-Length" => body.size.to_s }, [body]]
           else

--- a/spec/ops/middleware/revision_middleware_spec.rb
+++ b/spec/ops/middleware/revision_middleware_spec.rb
@@ -33,5 +33,11 @@ describe E20::Ops::Middleware::RevisionMiddleware do
       status, headers, body = middleware.call({})
       headers["X-Revision"].should == "the_revision"
     end
+    
+    it "returns the current running revision when configured outside /system/revision" do
+      middleware = E20::Ops::Middleware::RevisionMiddleware.new(app, :revision => "rev", :path_info => '/git/revision')
+      status, headers, body = middleware.call({"PATH_INFO" => "/git/revision"})
+      body.should == ["rev\n"]
+    end
   end
 end


### PR DESCRIPTION
So my web server is set to use sendfile in all subdirectories of /system in my Rails app. I can't use the default endpoint because nginx just returns a 404 since the file 'revision' does not exist. This allows you to set any arbitrary endpoint in your rackup file if needed. It defaults to '/system/revision' so no existing code will have to be changed. Includes change, test, and documentation update.
